### PR TITLE
disconnect created entity in update test from em session

### DIFF
--- a/generators/entity-server/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -632,7 +632,9 @@ _%>
         int databaseSizeBeforeUpdate = <%= entityInstance %>Repository.findAll().size();
 
         // Update the <%= entityInstance %>
-        <%= entityClass %> updated<%= entityClass %> = <%= entityInstance %>Repository.findOne(<%= entityInstance %>.getId());
+        <%= entityClass %> updated<%= entityClass %> = <%= entityInstance %>Repository.findOne(<%= entityInstance %>.getId());<% if (databaseType === 'sql') { %>
+        // Disconnect from session so that the updates on updated<%= entityClass %> are not directly saved in db
+        em.detach(updated<%= entityClass %>);<% } %>
         <%_ if (fluentMethods && fields.length > 0) { _%>
         updated<%= entityClass %><% for (idx in fields) { %>
             .<%= fields[idx].fieldName %>(<%='UPDATED_' + fields[idx].fieldNameUnderscored.toUpperCase()%>)<% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %>


### PR DESCRIPTION
in order to update the entity trough the api we need to disconnect the
created entity from the em session because else the changes of the
entity will be propagated directly to the db and errors in the api call
will not be detected

Fix #6671

(cherry picked from commit 41eabf5)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
